### PR TITLE
ColorblindHelper: fix NullReferenceException

### DIFF
--- a/ColorblindHelper/Assets/Scripts/ColorBlindHelper.cs
+++ b/ColorblindHelper/Assets/Scripts/ColorBlindHelper.cs
@@ -53,7 +53,7 @@ public class ColorBlindHelper : MonoBehaviour
 			foreach (var kvp in loadedMods.Values)
 			{
 				var go = (List<GameObject>) gameObjectsField.GetValue(kvp, null);
-				foreach (var g in go.Where(x => x.GetComponentsInChildren<Component>(true).Any(y => y.GetType().Name.Equals("KMColorblindMode"))))
+				foreach (var g in go.Where(x => x.GetComponentsInChildren<Component>(true).Any(y => y != null && y.GetType().Name.Equals("KMColorblindMode"))))
 				{
 					if (g.GetComponent<ColorBlindHelper>()) continue;
 					if (g.GetComponent<KMBombModule>())


### PR DESCRIPTION
This commit adds a null check that allows the mod to correctly find colour-blind enabled modules. Previously it was always showing 'No colorblind modules present' on the holdable.